### PR TITLE
添加,ExtractWordView,一个可以提取单词的ListView,支持"放大镜"效果.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ Demo地址：[Download here](http://7u2jsw.com1.z0.glb.clouddn.com/githubCustomS
 项目地址：https://github.com/guanchao/ScrollerCalendar  
 效果图：![Renderings](https://raw.githubusercontent.com/guanchao/ScrollerCalendar/master/images/sample2.gif)  
 
+1. ExtractWordView  
+一个可以提取单词的ListView,支持"放大镜"效果.  
+项目地址：https://github.com/jcodeing/ExtractWordView  
+效果图：![Renderings](https://raw.githubusercontent.com/jcodeing/ExtractWordView/master/lookme.gif)  
+Demo地址：[Download here](https://raw.githubusercontent.com/jcodeing/ExtractWordView/master/ExtractWordView-demo.apk)   
+
 #### 二、ActionBar  
 1. ActionBarSherlock  
 为Android所有版本提供统一的ActionBar，解决4.0以下ActionBar的适配问题  


### PR DESCRIPTION
这是一个，可以提取 英文单词 的 ListView Demo
长按文章时，启动题词功能，含有 ”放大镜“ 功能，打开了手指触摸下的视角。
长按，后可随意滑动，滑到那里，取到那里。松开后，便可获取，以选择的单词。

在android原生控件ListView上实现滑动取词。
可以随意滑动取词，跨item进行取词。取词代码在ListView的onTouchEvent中处理。

用法:
只需将widget下的 
    EWListView.java
    EWListViewChildET.java
两个文件copy到你的工程中，
ListView用EWListView，或者，直接复制里面的逻辑到你自定义的ListView中即可
Item用EWListViewChildET，或者copy，逻辑到你的item中。